### PR TITLE
added Module::Pluggable to prereqs because it is being removed from core

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ copyright_year   = 2004
 [@RJBS]
 [Prereqs]
 Email::Simple = 1.998
+Module::Pluggable = 1.5
 
 [RemovePrereqs]
 remove = Courriel


### PR DESCRIPTION
You get warnings like this "Module::Pluggable will be removed from the Perl core distribution in the next major release. Please install it from CPAN. It is being used at <SNIP>/local/lib/perl5/Email/Abstract.pm, line 14.".  It "may" also be worth adding Scalar::Util (personally I tend to add every use which covers for any eventuality).  I kept with the 1.5 version which is specified in the code even though we're up to 5.2.
